### PR TITLE
Set default NAN_VALUE as -9999

### DIFF
--- a/src/org/myworldgis/io/asciigrid/AsciiGridFileWriter.java
+++ b/src/org/myworldgis/io/asciigrid/AsciiGridFileWriter.java
@@ -74,7 +74,7 @@ public final strictfp class AsciiGridFileWriter implements AsciiGridConstants {
         _out.println();
         
         if (Double.isNaN(nanValue)) {
-            _nanString = "NaN";
+            _nanString = "-9999";
         } else {
             _nanString = VALUE_FORMAT.format(nanValue);
         }


### PR DESCRIPTION
Since ArcMap 10.2 can not recognize ASC file when NODATA_VALUE is NaN, please set default NAN_VALUE as -9999