### PR TITLE
To fix Issue #20; parsing sci notation in gridfiles

### DIFF
--- a/src/org/myworldgis/io/asciigrid/AsciiGridFileReader.java
+++ b/src/org/myworldgis/io/asciigrid/AsciiGridFileReader.java
@@ -149,6 +149,7 @@ public final strictfp class AsciiGridFileReader implements AsciiGridConstants {
                 String token = tokens.nextToken();
                 if (token.length() > 0) {
                     try {
+                        token = token.replace('e', 'E'); // NumberFormat.parse only accepts an uppercase E for scientific notation. -James Hovet 10/2020
                         Number n = VALUE_FORMAT.parse(token);
                         if ((n != null) && (n.doubleValue() != _nanValue)) { 
                             value = n.doubleValue();


### PR DESCRIPTION
After testing, discovered that sci notation with a capital E did work,
so I just inserted a quick string replace from 'e' to 'E' before
parsing with Java's NumberFormat system as before.