### PR TITLE
Fix #33; Swapped out sun image loading library calls to ImageIO calls

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -7,9 +7,9 @@ The Java source code (files in the src directory whose names end in ".java") and
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
- * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
- * The names of its contributors may not be used to endorse or promote products derived from this software without specific prior written permission.
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+* The names of its contributors may not be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
@@ -69,9 +69,8 @@ ESRI is a trademark of Environmental Systems Research Institute, Inc.
 
 --------------------------------------------------------------------------------
 
-The Java Advanced Imaging libraries (the binary files jai_codec-1.1.3.jar and
-jai_core-1.1.3.jar) are copyright (c) 2006 Sun Microsystems, and are made 
-available under the following license:
+The Java Advanced Imaging libraries (the binary file jai_core-1.1.3.jar) are copyright
+(c) 2006 Sun Microsystems, and are made available under the following license:
 
 Sun Microsystems, Inc.
 Binary Code License Agreement

--- a/README.md
+++ b/README.md
@@ -1665,9 +1665,9 @@ The Java source code (files in the src directory whose names end in ".java") and
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
- * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
- * The names of its contributors may not be used to endorse or promote products derived from this software without specific prior written permission.
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+* The names of its contributors may not be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
@@ -1727,9 +1727,8 @@ ESRI is a trademark of Environmental Systems Research Institute, Inc.
 
 --------------------------------------------------------------------------------
 
-The Java Advanced Imaging libraries (the binary files jai_codec-1.1.3.jar and
-jai_core-1.1.3.jar) are copyright (c) 2006 Sun Microsystems, and are made 
-available under the following license:
+The Java Advanced Imaging libraries (the binary file jai_core-1.1.3.jar) are copyright
+(c) 2006 Sun Microsystems, and are made available under the following license:
 
 Sun Microsystems, Inc.
 Binary Code License Agreement

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ libraryDependencies ++= Seq(
   "commons-codec"              % "commons-codec"      % "1.10",
   "org.ngs"                    % "ngunits"            % "1.0.0" from "https://s3.amazonaws.com/ccl-artifacts/ngunits-1.0.jar",
   "javax.media"                % "jai_core"           % "1.1.3" from "https://s3.amazonaws.com/ccl-artifacts/jai_core-1.1.3.jar",
-  "com.sun.media"              % "jai_codec"          % "1.1.3" from "https://s3.amazonaws.com/ccl-artifacts/jai_codec-1.1.3.jar", 
   "org.tinfour"                % "TinfourCore"        % "2.1.5",
   "com.googlecode.json-simple" % "json-simple"        % "1.1.1")
 


### PR DESCRIPTION
Fix #33 ; Replace com.sun.media calls to ImageIO calls. A bit of research revealed that those sun classes are not recommended to be called directly. These days, using ImageIO to do simple image loading is the recommended replacement. 