### PR TITLE
Docs: Update URLs to GeoAPI Well-Known Text (WKT)

### DIFF
--- a/documentation.conf
+++ b/documentation.conf
@@ -217,7 +217,7 @@ be unpredictable.
     description: """
 Loads a new global projection used for projecting or re- projecting
 GIS data as it is loaded from a file. The file must contain a valid
-<a href="http://geoapi.sourceforge.net/2.0/javadoc/org/opengis/referencing/doc-files/WKT.html" target="_blank">
+<a href="https://www.geoapi.org/3.0/javadoc/org/opengis/referencing/doc-files/WKT.html" target="_blank">
 Well-Known Text (WKT)</a> projection description.
 
 WKT projection files are frequently distributed alongside GIS data
@@ -262,7 +262,7 @@ for a complete list of WKT projections and their parameters.
     description: """
 Sets the global projection used for projecting or re- projecting
 GIS data as it is loaded. The *system* must be either a string
-in <a href="http://geoapi.sourceforge.net/2.0/javadoc/org/opengis/referencing/doc-files/WKT.html" target="_blank">
+in <a href="http://www.geoapi.org/3.0/javadoc/org/opengis/referencing/doc-files/WKT.html" target="_blank">
 Well-Known Text (WKT) format</a>, or a NetLogo list that consists
 of WKT converted to a list by moving each keyword inside its
 associated brackets and putting quotes around it. The latter is


### PR DESCRIPTION
Update the URLs to GeoAPI documentation of the Well-Known Text (WKT) format, since the GeoAPI docs have moved.