### PR TITLE
Fix create turtles inside

### DIFF
--- a/examples/create-turtles-inside-polygon.nlogo
+++ b/examples/create-turtles-inside-polygon.nlogo
@@ -76,6 +76,27 @@ to test-turtles
     clear-turtles
   ]
 end
+
+
+to test-num-agents-created
+  clear-all
+  set dataset gis:load-dataset "./shared-datasets/countries.shp"
+  gis:set-world-envelope gis:envelope-of dataset
+  gis:set-drawing-color red
+  gis:draw dataset 1
+
+  let num-to-create 5
+
+  foreach gis:feature-list-of dataset [ country ->
+    let cnt 0
+    gis:create-turtles-inside-polygon country turtles num-to-create [
+     set cnt cnt + 1
+    ]
+    if cnt != num-to-create [
+      error "wrong number of agents created"
+    ]
+  ]
+end
 @#$#@#$#@
 GRAPHICS-WINDOW
 210
@@ -446,7 +467,7 @@ false
 Polygon -7500403 true true 270 75 225 30 30 225 75 270
 Polygon -7500403 true true 30 75 75 30 270 225 225 270
 @#$#@#$#@
-NetLogo 6.1.1
+NetLogo 6.2.1
 @#$#@#$#@
 @#$#@#$#@
 @#$#@#$#@

--- a/src/org/myworldgis/netlogo/CreateTurtlesInsidePolygon.java
+++ b/src/org/myworldgis/netlogo/CreateTurtlesInsidePolygon.java
@@ -17,9 +17,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-public strictfp class CreateTurtlesInsidePolygon {
+public class CreateTurtlesInsidePolygon {
 
-    private static abstract strictfp class TurtlesInsidePolygon extends GISExtension.Command implements CustomAssembled {
+    private static abstract class TurtlesInsidePolygon extends GISExtension.Command implements CustomAssembled {
 
         protected abstract Map<String, Integer> getPropertyNameToTurtleVarIndex(List<String> variableNamesList, List<String> properties, Argument[] args) throws ExtensionException;
 
@@ -80,7 +80,7 @@ public strictfp class CreateTurtlesInsidePolygon {
         }
     }
 
-    public static strictfp class TurtlesInsidePolygonAutomatic extends TurtlesInsidePolygon {
+    public static class TurtlesInsidePolygonAutomatic extends TurtlesInsidePolygon {
 
         public Syntax getSyntax() {
             return VectorFeaturesToTurtlesUtil.makeTurtleCreationCommandSyntax(new Object[]{Syntax.WildcardType(), Syntax.TurtlesetType(), Syntax.NumberType(), Syntax.CommandBlockType() | Syntax.OptionalType()});
@@ -91,7 +91,7 @@ public strictfp class CreateTurtlesInsidePolygon {
         }
     }
 
-    public static strictfp class TurtlesInsidePolygonManual extends TurtlesInsidePolygon {
+    public static class TurtlesInsidePolygonManual extends TurtlesInsidePolygon {
 
         public Syntax getSyntax() {
             return VectorFeaturesToTurtlesUtil.makeTurtleCreationCommandSyntax(new Object[]{Syntax.WildcardType(), Syntax.TurtlesetType(), Syntax.NumberType(), Syntax.ListType(), Syntax.CommandBlockType() | Syntax.OptionalType()});

--- a/src/org/myworldgis/netlogo/CreateTurtlesInsidePolygon.java
+++ b/src/org/myworldgis/netlogo/CreateTurtlesInsidePolygon.java
@@ -2,10 +2,7 @@ package org.myworldgis.netlogo;
 
 import com.vividsolutions.jts.geom.Coordinate;
 import org.myworldgis.util.VectorFeaturesToTurtlesUtil;
-import org.nlogo.agent.AgentSet;
-import org.nlogo.agent.TreeAgentSet;
-import org.nlogo.agent.Turtle;
-import org.nlogo.agent.World;
+import org.nlogo.agent.*;
 import org.nlogo.api.AgentException;
 import org.nlogo.api.Argument;
 import org.nlogo.api.ExtensionException;
@@ -15,13 +12,14 @@ import org.nlogo.nvm.AssemblerAssistant;
 import org.nlogo.nvm.CustomAssembled;
 import org.nlogo.nvm.ExtensionContext;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-public class CreateTurtlesInsidePolygon {
+public strictfp class CreateTurtlesInsidePolygon {
 
-    private static abstract class TurtlesInsidePolygon extends GISExtension.Command implements CustomAssembled {
+    private static abstract strictfp class TurtlesInsidePolygon extends GISExtension.Command implements CustomAssembled {
 
         protected abstract Map<String, Integer> getPropertyNameToTurtleVarIndex(List<String> variableNamesList, List<String> properties, Argument[] args) throws ExtensionException;
 
@@ -59,6 +57,7 @@ public class CreateTurtlesInsidePolygon {
 
             Map<String, Integer> propertyNameToTurtleVarIndex = getPropertyNameToTurtleVarIndex(variableNamesList, propertyNamesList, args);
 
+            TreeAgentSet createdAgentSet = new TreeAgentSet(breedAgentSet.kind(), "temp_agentset_for_create_turtles_inside_polygon");
             for (int i = 0; i < numToMake; i++){
                 Coordinate coord = vectorFeature.getRandomPointInsidePolygon(context.getRNG());
                 Turtle turtle = VectorFeaturesToTurtlesUtil.CreateTurtleAtGISCoordinate(breedAgentSet, coord, world, nvmContext);
@@ -69,9 +68,10 @@ public class CreateTurtlesInsidePolygon {
                     continue;
                 }
                 VectorFeaturesToTurtlesUtil.setTurtleVariablesToVectorFeatureProperties(turtle, vectorFeature, propertyNameToTurtleVarIndex);
+                createdAgentSet.add(turtle);
             }
 
-            nvmContext.runExclusiveJob(breedAgentSet, nvmContext.ip + 1);
+            nvmContext.runExclusiveJob(createdAgentSet, nvmContext.ip + 1);
         }
 
         public void assemble (AssemblerAssistant assemblerAssistant){
@@ -80,7 +80,7 @@ public class CreateTurtlesInsidePolygon {
         }
     }
 
-    public static class TurtlesInsidePolygonAutomatic extends TurtlesInsidePolygon {
+    public static strictfp class TurtlesInsidePolygonAutomatic extends TurtlesInsidePolygon {
 
         public Syntax getSyntax() {
             return VectorFeaturesToTurtlesUtil.makeTurtleCreationCommandSyntax(new Object[]{Syntax.WildcardType(), Syntax.TurtlesetType(), Syntax.NumberType(), Syntax.CommandBlockType() | Syntax.OptionalType()});
@@ -91,7 +91,7 @@ public class CreateTurtlesInsidePolygon {
         }
     }
 
-    public static class TurtlesInsidePolygonManual extends TurtlesInsidePolygon {
+    public static strictfp class TurtlesInsidePolygonManual extends TurtlesInsidePolygon {
 
         public Syntax getSyntax() {
             return VectorFeaturesToTurtlesUtil.makeTurtleCreationCommandSyntax(new Object[]{Syntax.WildcardType(), Syntax.TurtlesetType(), Syntax.NumberType(), Syntax.ListType(), Syntax.CommandBlockType() | Syntax.OptionalType()});

--- a/src/org/myworldgis/netlogo/CreateTurtlesInsidePolygon.java
+++ b/src/org/myworldgis/netlogo/CreateTurtlesInsidePolygon.java
@@ -2,7 +2,10 @@ package org.myworldgis.netlogo;
 
 import com.vividsolutions.jts.geom.Coordinate;
 import org.myworldgis.util.VectorFeaturesToTurtlesUtil;
-import org.nlogo.agent.*;
+import org.nlogo.agent.AgentSet;
+import org.nlogo.agent.TreeAgentSet;
+import org.nlogo.agent.Turtle;
+import org.nlogo.agent.World;
 import org.nlogo.api.AgentException;
 import org.nlogo.api.Argument;
 import org.nlogo.api.ExtensionException;

--- a/tests.txt
+++ b/tests.txt
@@ -241,3 +241,7 @@ testCreateTurtlesInsidePolygon_manual
 testCreateTurtlesInsidePolygon_turtles_as_agentset
   OPEN> extensions/gis/examples/create-turtles-inside-polygon.nlogo
   O> test-turtles
+
+testCreateTurtlesInsidePolygon_num_turtles_created
+  OPEN> extensions/gis/examples/create-turtles-inside-polygon.nlogo
+  O> test-num-agents-created


### PR DESCRIPTION
There is a bug where the create turtles inside method was executing the code within its netlogo code block for *all agents in the breed agentset* instead of just the agents created by it. This PR fixes that and brings the behavior inline with the behavior of `create-turtles`